### PR TITLE
Fix Enter Event & Mathjax Equations. 

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1869,19 +1869,6 @@ var keyHandlers = {
         range = self._createRange( nodeAfterSplit, 0 );
         self.setSelection( range );
         self._updatePath( range, true );
-
-        /* Scroll into view
-        if ( nodeAfterSplit.nodeType === TEXT_NODE ) {
-            nodeAfterSplit = nodeAfterSplit.parentNode;
-        }
-        var doc = self._doc,
-            body = self._body;
-        if ( nodeAfterSplit.offsetTop + nodeAfterSplit.offsetHeight >
-                ( doc.documentElement.scrollTop || body.scrollTop ) +
-                body.offsetHeight ) {
-            nodeAfterSplit.scrollIntoView( false );
-        }
-        */
     },
     backspace: function ( self, event, range ) {
         self._removeZWS();

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1870,7 +1870,7 @@ var keyHandlers = {
         self.setSelection( range );
         self._updatePath( range, true );
 
-        // Scroll into view
+        /* Scroll into view
         if ( nodeAfterSplit.nodeType === TEXT_NODE ) {
             nodeAfterSplit = nodeAfterSplit.parentNode;
         }
@@ -1881,6 +1881,7 @@ var keyHandlers = {
                 body.offsetHeight ) {
             nodeAfterSplit.scrollIntoView( false );
         }
+        */
     },
     backspace: function ( self, event, range ) {
         self._removeZWS();

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1941,10 +1941,10 @@ var keyHandlers = {
                     // If the equation is at the end of the node, set the caret before the equation, 
                     // otherwise set it at the end of the node, (the element before the <br> tag).
                     if (secondLastNode && (secondLastNode === mathjaxParent)){
-                        var spanRange = new Range();
+                        var spanRange = document.createRange();
                         spanRange.setEndAfter(mathjaxParent);
                     } else {
-                        var spanRange = new Range();
+                        var spanRange = document.createRange();
                         spanRange.setStartBefore(nodesInParent[nodesInParent.length - 1]);
                     }
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1931,9 +1931,21 @@ var keyHandlers = {
                     while ( mathjaxParent.className != "mathjax") {
                          mathjaxParent = mathjaxParent.parentNode;
                     }
+                    // Get the div containing the equation.
+                    var parent = mathjaxParent.parentNode;
+                    var nodesInParent = parent.childNodes;
+                    var secondLastNode = nodesInParent.childNodes[nodesInParent.length - 2];
 
-                    var spanRange = new Range();
-                    spanRange.setEndAfter(mathjaxParent);
+                    // Check if the equation is at the end of the node, the second last element. <br> is always the last element.
+                    // If the equation is at the end of the node, set the caret before the equation, 
+                    // otherwise set it at the end of the node, (the element before the <br> tag).
+                    if (secondLastNode && (secondLastNode === mathjaxParent)){
+                        var spanRange = new Range();
+                        spanRange.setEndAfter(mathjaxParent);
+                    } else {
+                        var spanRange = new Range();
+                        spanRange.setStartBefore(nodesInParent[nodesInParent.length - 1]);
+                    }
 
                     self.setSelection(spanRange);
                 } else {


### PR DESCRIPTION
The cursor should move to the end of the previous line or the start of
a Mathjax equation because SVG does strange things when it is the
selected element (you could select any element). Therefore we need to
test this case in the backspace event.

and 

Handle Mathjax separately when it is the only thing in the editor. If
there is only a Mathjax equation then instead of deleting the div that
contains them, we delete all the nodes inside the div and leave the div
alone.
