### PR TITLE
Navigate past Mathjax Equations.

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1887,7 +1887,7 @@ var keyHandlers = {
 
         // Filter childnodes, that are textNodes.
         for (node=node.firstChild;node;node=node.nextSibling){
-            if (node.nodeType === 3) textNodes.push(node);
+            if (node.nodeType === 3 && node.textContet && node.textContent === " ") textNodes.push(node);
         }
         var isOnlyMathjax = ((textNodes.length === 1 || textNodes.length === 2) && range.commonAncestorContainer.querySelectorAll('.mathjax').length === 1 && (ancestor.childNodes.length === 3 || ancestor.childNodes.length === 4));
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1988,9 +1988,13 @@ var keyHandlers = {
             }
         }
         else {
-            if (checkInSVG.test(range.commonAncestorContainer.parentElement)){
-                event.preventDefault();
-                detach(range.commonAncestorContainer.parentElement);
+            // If the commonAncestor was in a mathjax equation, delete the parent. Namely the mathjax equation.
+            if (range.commonAncestorContainer && 
+                range.commonAncestorContainer.parentElement && 
+                checkInSVG.test(range.commonAncestorContainer.nodeName)
+            ) {
+                    event.preventDefault();
+                    detach(range.commonAncestorContainer.parentElement);
             }
             self.setSelection( range );
             setTimeout( function () { afterDelete( self ); }, 0 );

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2084,10 +2084,63 @@ var keyHandlers = {
 
         self.setSelection( range );
     },
-    left: function ( self ) {
+    left: function ( self, event, range) {
+        var selection = self._doc.getSelection();
+
+        // We're not interested in things that are not Carets.
+        if (!selection.isCollapsed) { return; }
+        // or anything that doesn't have an anchorNode.
+        if(!selection.anchorNode) { return; }
+
+        var anchorNode = selection.anchorNode;
+        var anchorPreviousNode = anchorNode.previousSibling;
+
+        if (selection.anchorOffset === 0 &&
+            anchorNode &&
+            anchorPreviousNode && 
+            /SPAN/i.test(anchorPreviousNode.nodeName) && 
+            anchorPreviousNode.classList.contains("mathjax")
+        ) {
+            // this is a mathjax equation, prevent defualt.
+            event.preventDefault();
+
+            // create a new range
+            var leftRange = document.createRange();
+            leftRange.setStartBefore(anchorPreviousNode);
+            leftRange.setEndBefore(anchorPreviousNode);
+            
+            // set a selection.
+            self.setSelection(leftRange);
+        }
+
         self._removeZWS();
     },
-    right: function ( self ) {
+    right: function ( self, event, range) {
+        var selection = self._doc.getSelection();
+
+        // We're not interested in things that are not Carets.
+        if (!selection.isCollapsed) { return; }
+
+        var anchorNode = selection.anchorNode;
+        var anchorNextNode = anchorNode.nextSibling;
+
+        if (
+            anchorNextNode && 
+            /SPAN/i.test(anchorNextNode.nodeName) && 
+            anchorNextNode.classList.contains("mathjax")
+        ) {
+            // this is a mathjax equation, prevent defualt.
+            event.preventDefault();
+
+            // create a new range
+            var rightRange = document.createRange();
+            rightRange.setStartAfter(anchorNextNode);
+            rightRange.setEndAfter(anchorNextNode);
+            
+            // set a selection.
+            self.setSelection(rightRange);
+        }
+
         self._removeZWS();
     }
 };

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2101,12 +2101,15 @@ var keyHandlers = {
         var anchorNode = selection.anchorNode;
         var anchorPreviousNode = anchorNode.previousSibling;
 
-        if (selection.anchorOffset === 0 &&
-            anchorNode &&
-            anchorPreviousNode && 
-            /SPAN/i.test(anchorPreviousNode.nodeName) && 
-            anchorPreviousNode.classList.contains("mathjax")
-        ) {
+        // Test conditions for selection being at the start of the textnode.
+        var validNodes = !!(anchorNode && anchorPreviousNode);
+        var caretAtEndOfNode = selection.anchorOffset === 0;
+
+        // Test is SPAN and has mathjax class.
+        var isMathjaxIE = !!(validNodes && anchorPreviousNode.matchesSelector && anchorPreviousNode.matchesSelector('span.mathjax'));
+        var isMathjax  = !!(validNodes && anchorPreviousNode.matches && anchorPreviousNode.matches('span.mathjax'));
+
+        if (caretAtEndOfNode && (isMathjax || isMathjaxIE)) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 
@@ -2130,11 +2133,13 @@ var keyHandlers = {
         var anchorNode = selection.anchorNode;
         var anchorNextNode = anchorNode.nextSibling;
 
-        if (
-            anchorNextNode && 
-            /SPAN/i.test(anchorNextNode.nodeName) && 
-            anchorNextNode.classList.contains("mathjax")
-        ) {
+        var validNodes = !!(anchorNode && anchorNextNode);
+        // Test is SPAN and has mathjax class.
+        var isMathjaxIE = !!(validNodes && anchorNextNode.matchesSelector && anchorNextNode.matchesSelector('span.mathjax'));
+        var isMathjax  = !!(validNodes && anchorNextNode.matches && anchorNextNode.matches('span.mathjax'));
+
+
+        if (caretAtEndOfNode && (isMathjax || isMathjaxIE)) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1887,9 +1887,9 @@ var keyHandlers = {
 
         // Filter childnodes, that are textNodes.
         for (node=node.firstChild;node;node=node.nextSibling){
-            if (node.nodeType == 3) textNodes.push(node);
+            if (node.nodeType === 3) textNodes.push(node);
         }
-        var isOnlyMathjax = ((textNodes.length === 1 || textNodes.length === 2) && range.commonAncestorContainer.querySelectorAll('.mathjax').length === 1 && (ancestor.childNodes.length == 3 || ancestor.childNodes.length == 4));
+        var isOnlyMathjax = ((textNodes.length === 1 || textNodes.length === 2) && range.commonAncestorContainer.querySelectorAll('.mathjax').length === 1 && (ancestor.childNodes.length === 3 || ancestor.childNodes.length === 4));
 
         if (!isOnlyMathjax && !range.collapsed ) {
             event.preventDefault();
@@ -1957,11 +1957,11 @@ var keyHandlers = {
                     // Check if the equation is at the end of the node, the second last element. <br> is always the last element.
                     // If the equation is at the end of the node, set the caret before the equation, 
                     // otherwise set it at the end of the node, (the element before the <br> tag).
-                    if (secondLastNode && (secondLastNode === mathjaxParent)){
-                        var spanRange = document.createRange();
+                    var spanRange = document.createRange();
+
+                    if (secondLastNode && (secondLastNode === mathjaxParent)){                        
                         spanRange.setEndAfter(mathjaxParent);
                     } else {
-                        var spanRange = document.createRange();
                         spanRange.setStartBefore(nodesInParent[nodesInParent.length - 1]);
                     }
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2103,13 +2103,13 @@ var keyHandlers = {
 
         // Test conditions for selection being at the start of the textnode.
         var validNodes = !!(anchorNode && anchorPreviousNode);
-        var caretAtEndOfNode = selection.anchorOffset === 0;
+        var caretAtStartOfNode = selection.anchorOffset === 0;
 
         // Test is SPAN and has mathjax class.
         var isMathjaxIE = !!(validNodes && anchorPreviousNode.matchesSelector && anchorPreviousNode.matchesSelector('span.mathjax'));
         var isMathjax  = !!(validNodes && anchorPreviousNode.matches && anchorPreviousNode.matches('span.mathjax'));
 
-        if (caretAtEndOfNode && (isMathjax || isMathjaxIE)) {
+        if (caretAtStartOfNode && (isMathjax || isMathjaxIE)) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 
@@ -2139,7 +2139,7 @@ var keyHandlers = {
         var isMathjax  = !!(validNodes && anchorNextNode.matches && anchorNextNode.matches('span.mathjax'));
 
 
-        if (caretAtEndOfNode && (isMathjax || isMathjaxIE)) {
+        if (isMathjax || isMathjaxIE) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1878,7 +1878,6 @@ var keyHandlers = {
 
         var checkInSVG = /svg|use|g|SCRIPT/i;
         // If not collapsed, delete contents
-
         // Check if there is only a Mathjax Equation in the iFrame.
         var ancestor = range.commonAncestorContainer;
         var node = ancestor;
@@ -1953,7 +1952,7 @@ var keyHandlers = {
                     // Get the div containing the equation.
                     var parent = mathjaxParent.parentNode;
                     var nodesInParent = parent.childNodes;
-                    var secondLastNode = nodesInParent.childNodes[nodesInParent.length - 2];
+                    var secondLastNode = nodesInParent[nodesInParent.length - 2];
 
                     // Check if the equation is at the end of the node, the second last element. <br> is always the last element.
                     // If the equation is at the end of the node, set the caret before the equation, 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1910,7 +1910,7 @@ var keyHandlers = {
                 ancestor.removeChild(childNodes[0]);
             }            
             ancestor.innerHTML = " <br>";
-            var ancestorRange = document.createRange();
+            var ancestorRange = self._doc.createRange();
             ancestorRange.setStartAfter(ancestor);
             ancestorRange.setEndBefore(ancestor);
             self.setSelection(ancestorRange);
@@ -1959,9 +1959,9 @@ var keyHandlers = {
                     // Check if the equation is at the end of the node, the second last element. <br> is always the last element.
                     // If the equation is at the end of the node, set the caret before the equation, 
                     // otherwise set it at the end of the node, (the element before the <br> tag).
-                    var spanRange = document.createRange();
+                    var spanRange = self._doc.createRange();
 
-                    if (secondLastNode && (secondLastNode === mathjaxParent)){                        
+                    if (secondLastNode && (secondLastNode === mathjaxParent)){
                         spanRange.setEndAfter(mathjaxParent);
                     } else {
                         spanRange.setStartBefore(nodesInParent[nodesInParent.length - 1]);
@@ -2111,7 +2111,7 @@ var keyHandlers = {
             event.preventDefault();
 
             // create a new range
-            var leftRange = document.createRange();
+            var leftRange = self._doc.createRange();
             leftRange.setStartBefore(anchorPreviousNode);
             leftRange.setEndBefore(anchorPreviousNode);
             

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2144,7 +2144,7 @@ var keyHandlers = {
             event.preventDefault();
 
             // create a new range
-            var rightRange = document.createRange();
+            var rightRange = self._doc.createRange();
             rightRange.setStartAfter(anchorNextNode);
             rightRange.setEndAfter(anchorNextNode);
             

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2118,8 +2118,8 @@ keyHandlers[ ctrlKey + 'shift-8' ] = mapKeyTo( 'makeUnorderedList' );
 keyHandlers[ ctrlKey + 'shift-9' ] = mapKeyTo( 'makeOrderedList' );
 keyHandlers[ ctrlKey + '[' ] = mapKeyTo( 'decreaseQuoteLevel' );
 keyHandlers[ ctrlKey + ']' ] = mapKeyTo( 'increaseQuoteLevel' );
-keyHandlers[ ctrlKey + 'y' ] = mapKeyTo( 'redo' );
-keyHandlers[ ctrlKey + 'z' ] = mapKeyTo( 'undo' );
+// keyHandlers[ ctrlKey + 'y' ] = mapKeyTo( 'redo' );
+// keyHandlers[ ctrlKey + 'z' ] = mapKeyTo( 'undo' );
 keyHandlers[ ctrlKey + 'shift-z' ] = mapKeyTo( 'redo' );
 
 // Ref: http://unixpapa.com/js/key.html

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1887,7 +1887,7 @@ var keyHandlers = {
 
         // Filter childnodes, that are textNodes.
         for (node=node.firstChild;node;node=node.nextSibling){
-            if (node.nodeType === 3 && node.textContet && node.textContent === " ") textNodes.push(node);
+            if (node.nodeType === TEXT_NODE && node.textContent && node.textContent === " ") textNodes.push(node);
         }
         var isOnlyMathjax = ((textNodes.length === 1 || textNodes.length === 2) && range.commonAncestorContainer.querySelectorAll('.mathjax').length === 1 && (ancestor.childNodes.length === 3 || ancestor.childNodes.length === 4));
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1891,12 +1891,14 @@ var keyHandlers = {
         }
         var isOnlyMathjax = ((textNodes.length === 1 || textNodes.length === 2) && range.commonAncestorContainer.querySelectorAll('.mathjax').length === 1 && (ancestor.childNodes.length === 3 || ancestor.childNodes.length === 4));
 
+        // There is only a colasped range, delre the contents of the range.
         if (!isOnlyMathjax && !range.collapsed ) {
             event.preventDefault();
             deleteContentsOfRange( range );
             afterDelete( self, range );
         }
 
+        // If there is only a mathjax equation, remove the childnodes of the range, to keep the dom from being empty.
         if (isOnlyMathjax) {
             event.preventDefault();
             // Remove each child of the range.


### PR DESCRIPTION
IE won't navigate past Mathjax Equations, so we override the behaviour and use the selection API to set the selection to the other side of the equation. 

Also:
- Correct behaviour of checking if only a Mathjax equation exists in the editor.
- Remove key bindings for redo & undo.
- If we are trying to delete an element that is inside an SVG, remove the mathjax equation.
