### PR TITLE
Use msMatchesSelector & confirm that at end of node before navigating right.

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2106,7 +2106,7 @@ var keyHandlers = {
         var caretAtStartOfNode = selection.anchorOffset === 0;
 
         // Test is SPAN and has mathjax class.
-        var isMathjaxIE = !!(validNodes && anchorPreviousNode.matchesSelector && anchorPreviousNode.matchesSelector('span.mathjax'));
+        var isMathjaxIE = !!(validNodes && anchorPreviousNode.msMatchesSelector && anchorPreviousNode.msMatchesSelector('span.mathjax'));
         var isMathjax  = !!(validNodes && anchorPreviousNode.matches && anchorPreviousNode.matches('span.mathjax'));
 
         if (caretAtStartOfNode && (isMathjax || isMathjaxIE)) {
@@ -2135,7 +2135,7 @@ var keyHandlers = {
 
         var validNodes = !!(anchorNode && anchorNextNode);
         // Test is SPAN and has mathjax class.
-        var isMathjaxIE = !!(validNodes && anchorNextNode.matchesSelector && anchorNextNode.matchesSelector('span.mathjax'));
+        var isMathjaxIE = !!(validNodes && anchorNextNode.msMatchesSelector && anchorNextNode.msMatchesSelector('span.mathjax'));
         var isMathjax  = !!(validNodes && anchorNextNode.matches && anchorNextNode.matches('span.mathjax'));
 
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2106,10 +2106,11 @@ var keyHandlers = {
         var caretAtStartOfNode = selection.anchorOffset === 0;
 
         // Test is SPAN and has mathjax class.
+        var isMathjaxIOS = !!(validNodes && anchorPreviousNode.webkitMatchesSelector && anchorPreviousNode.webkitMatchesSelector('span.mathjax'));
         var isMathjaxIE = !!(validNodes && anchorPreviousNode.msMatchesSelector && anchorPreviousNode.msMatchesSelector('span.mathjax'));
         var isMathjax  = !!(validNodes && anchorPreviousNode.matches && anchorPreviousNode.matches('span.mathjax'));
 
-        if (caretAtStartOfNode && (isMathjax || isMathjaxIE)) {
+        if (caretAtStartOfNode && (isMathjax || isMathjaxIE || isMathjaxIOS)) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 
@@ -2136,10 +2137,11 @@ var keyHandlers = {
         var caretIsAtEndOfNode = selection.anchorOffset === selection.anchorNode.wholeText.length;
         var validNodes = !!(anchorNode && anchorNextNode);
         // Test is SPAN and has mathjax class.
+        var isMathjaxIOS = !!(validNodes && anchorNextNode.webkitMatchesSelector && anchorNextNode.webkitMatchesSelector('span.mathjax'));
         var isMathjaxIE = !!(validNodes && anchorNextNode.msMatchesSelector && anchorNextNode.msMatchesSelector('span.mathjax'));
         var isMathjax  = !!(validNodes && anchorNextNode.matches && anchorNextNode.matches('span.mathjax'));
 
-        if (caretIsAtEndOfNode && (isMathjax || isMathjaxIE)) {
+        if (caretIsAtEndOfNode && (isMathjax || isMathjaxIE || isMathjaxIOS)) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2092,9 +2092,9 @@ var keyHandlers = {
     },
     left: function ( self, event, range) {
         var selection = self._doc.getSelection();
-
         // We're not interested in things that are not Carets.
         if (!selection.isCollapsed) { return; }
+        
         // or anything that doesn't have an anchorNode.
         if(!selection.anchorNode) { return; }
 
@@ -2133,13 +2133,13 @@ var keyHandlers = {
         var anchorNode = selection.anchorNode;
         var anchorNextNode = anchorNode.nextSibling;
 
+        var caretIsAtEndOfNode = selection.anchorOffset === selection.anchorNode.wholeText.length;
         var validNodes = !!(anchorNode && anchorNextNode);
         // Test is SPAN and has mathjax class.
         var isMathjaxIE = !!(validNodes && anchorNextNode.msMatchesSelector && anchorNextNode.msMatchesSelector('span.mathjax'));
         var isMathjax  = !!(validNodes && anchorNextNode.matches && anchorNextNode.matches('span.mathjax'));
 
-
-        if (isMathjax || isMathjaxIE) {
+        if (caretIsAtEndOfNode && (isMathjax || isMathjaxIE)) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 

--- a/source/Node.js
+++ b/source/Node.js
@@ -91,7 +91,9 @@ function getPath ( node ) {
         if ( id = node.id ) {
             path += '#' + id;
         }
-        if ( className = node.className.trim() ) {
+
+
+        if (node.className && (className = node.className.trim()) ) {
             classNames = className.split( /\s\s*/ );
             classNames.sort();
             path += '.';

--- a/source/Node.js
+++ b/source/Node.js
@@ -93,7 +93,7 @@ function getPath ( node ) {
         }
 
 
-        if (node.className && (className = node.className.trim()) ) {
+        if (node.className && node.classList.trim && (className = node.className.trim()) ) {
             classNames = className.split( /\s\s*/ );
             classNames.sort();
             path += '.';

--- a/source/Node.js
+++ b/source/Node.js
@@ -93,7 +93,7 @@ function getPath ( node ) {
         }
 
 
-        if (node.className && node.classList.trim && (className = node.className.trim()) ) {
+        if (node.className && node.className.trim && (className = node.className.trim()) ) {
             classNames = className.split( /\s\s*/ );
             classNames.sort();
             path += '.';


### PR DESCRIPTION
We need to use msMatchesSelector instead of matchesSelector & the caret needs to be at the end of the node before we override the default behaviour and move the selection right. We are also confirming the trim method exists on an elements className before using the method (this is on the getPath method within Squire). 
