### PR TITLE
Fix Firefox Bugs

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2142,11 +2142,11 @@ var keyHandlers = {
         // Test conditions for selection being at the start of the textnode.
         var validNodes = !!(anchorNode && anchorPreviousNode);
         var caretAtStartOfNode = selection.anchorOffset === 0;
-        var isMathjaxIOS, isMathjaxIE, isMathjax;
+        
         // Test is SPAN and has mathjax class.
-        isMathjaxIOS = !!(validNodes && anchorPreviousNode.webkitMatchesSelector && anchorPreviousNode.webkitMatchesSelector('span.mathjax'));
-        isMathjaxIE = !!(validNodes && anchorPreviousNode.msMatchesSelector && anchorPreviousNode.msMatchesSelector('span.mathjax'));
-        isMathjax  = !!(validNodes && anchorPreviousNode.matches && anchorPreviousNode.matches('span.mathjax'));
+        var isMathjaxIOS = !!(validNodes && anchorPreviousNode.webkitMatchesSelector && anchorPreviousNode.webkitMatchesSelector('span.mathjax'));
+        var isMathjaxIE = !!(validNodes && anchorPreviousNode.msMatchesSelector && anchorPreviousNode.msMatchesSelector('span.mathjax'));
+        var isMathjax  = !!(validNodes && anchorPreviousNode.matches && anchorPreviousNode.matches('span.mathjax'));
 
         // create a range to set the selection to.
         var leftRange = self._doc.createRange();
@@ -2167,7 +2167,6 @@ var keyHandlers = {
 
             // set a selection.
             self.setSelection(leftRange);
-            return;
         }
     },
     right: function ( self, event, range) {

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2004,6 +2004,38 @@ var keyHandlers = {
                     event.preventDefault();
                     detach(mathjaxParent);
             }
+
+            var selection = self._doc.getSelection();
+            var anchorNode = selection.anchorNode;
+            var anchorOffset = selection.anchorOffset;
+            var previousSibling = anchorNode.previousSibling;
+
+            // Delete the equation if we are trying to delete the space infront of it, no browser copes well with a span tag sitting in the DOM with no text nodes next to it.
+
+            if (anchorNode.textContent && anchorNode.textContent.length) {
+                var caretAtStartOfNode = !!(anchorOffset === 0) || !!(anchorOffset === 1 && anchorNode.textContent.length === 1);
+            } else {
+                var caretAtStartOfNode = !!(anchorOffset === 0);
+            }
+            
+
+            if (anchorNode && previousSibling && caretAtStartOfNode) {
+                // Is an empty text node, backspace has been pressed
+                // and it's previous sibling is a mathjax equation
+                // then remove both elements.
+                var isMathjaxIOS = !!(previousSibling.webkitMatchesSelector && previousSibling.webkitMatchesSelector('span.mathjax'));
+                var isMathjaxIE = !!(previousSibling.msMatchesSelector && previousSibling.msMatchesSelector('span.mathjax'));
+                var isMathjax  = !!(previousSibling.matches && previousSibling.matches('span.mathjax'));
+                
+                if (isMathjaxIOS || isMathjaxIE || isMathjax) {
+                    event.preventDefault();
+                    detach(previousSibling);
+                }
+            }
+
+
+            //If we're trying to delete a mathjax equation, but the browser is giving us it's parent div, and telling us the caret was at a mathjax element.
+
             self.setSelection( range );
             setTimeout( function () { afterDelete( self ); }, 0 );
         }

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1990,27 +1990,22 @@ var keyHandlers = {
             }
         }
         else {
-            // If the commonAncestor was in a mathjax equation, delete the parent. Namely the mathjax equation.
-            if (range.commonAncestorContainer && 
-                range.commonAncestorContainer.parentElement && 
-                (checkInSVG.test(range.commonAncestorContainer.nodeName) || checkInSVG.test(range.commonAncestorContainer.parentElement.nodeName))
-            ) {
-                    // This is an element inside an SVG. We look up the DOM tree for the mathjax element.
-                    var mathjaxParent = range.commonAncestorContainer;
-                    // Loop up the tree to find the equation.
-                    while ( mathjaxParent.className != "mathjax") {
-                         mathjaxParent = mathjaxParent.parentNode;
+            // Traverse the DOM and search for a Mathjax equation that contains the range.commonAncestorContainer. If such equation exsits, delete it.
+            var currentSearchNode = range.commonAncestorContainer;
+            var mathjaxSpan = null;
 
-                         // We've reached the body of the iFrame, abort.
-                         if (mathjaxParent === self._doc.body) break;
-                    }
+            while ( currentSearchNode !== self._doc.body) {
+                if (currentSearchNode.nodeType === ELEMENT_NODE && currentSearchNode.classList.contains('mathjax')) {
+                    mathjaxSpan = currentSearchNode;
+                    break;
+                }
+                
+                currentSearchNode = currentSearchNode.parentNode;
+            }
 
-                    // Don't detach the entire body.
-                    if (!(mathjaxParent === self._doc.body)) {
-                        event.preventDefault();
-                        detach(mathjaxParent);
-                    }
-                    
+            if (mathjaxSpan) {
+                event.preventDefault();
+                detach(mathjaxSpan);
             }
 
             var selection = self._doc.getSelection();

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1993,10 +1993,16 @@ var keyHandlers = {
             // If the commonAncestor was in a mathjax equation, delete the parent. Namely the mathjax equation.
             if (range.commonAncestorContainer && 
                 range.commonAncestorContainer.parentElement && 
-                checkInSVG.test(range.commonAncestorContainer.nodeName)
+                (checkInSVG.test(range.commonAncestorContainer.nodeName) || checkInSVG.test(range.commonAncestorContainer.parentElement.nodeName))
             ) {
+                    // This is an element inside an SVG. We look up the DOM tree for the mathjax element.
+                    var mathjaxParent = range.commonAncestorContainer;
+                    // Loop up the tree to find the equation.
+                    while ( mathjaxParent.className != "mathjax") {
+                         mathjaxParent = mathjaxParent.parentNode;
+                    }
                     event.preventDefault();
-                    detach(range.commonAncestorContainer.parentElement);
+                    detach(mathjaxParent);
             }
             self.setSelection( range );
             setTimeout( function () { afterDelete( self ); }, 0 );

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2000,9 +2000,17 @@ var keyHandlers = {
                     // Loop up the tree to find the equation.
                     while ( mathjaxParent.className != "mathjax") {
                          mathjaxParent = mathjaxParent.parentNode;
+
+                         // We've reached the body of the iFrame, abort.
+                         if (mathjaxParent === self._doc.body) break;
                     }
-                    event.preventDefault();
-                    detach(mathjaxParent);
+
+                    // Don't detach the entire body.
+                    if (!(mathjaxParent === self._doc.body)) {
+                        event.preventDefault();
+                        detach(mathjaxParent);
+                    }
+                    
             }
 
             var selection = self._doc.getSelection();

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2178,8 +2178,10 @@ var keyHandlers = {
 
         var anchorNode = selection.anchorNode;
         var anchorNextNode = anchorNode.nextSibling;
+        
+        if (!anchorNode.textContent) return;
 
-        var caretIsAtEndOfNode = selection.anchorOffset === selection.anchorNode.wholeText.length;
+        var caretIsAtEndOfNode = selection.anchorOffset === anchorNode.textContent.length;
         var validNodes = !!(anchorNode && anchorNextNode);
         // Test is SPAN and has mathjax class.
         var isMathjaxIOS = !!(validNodes && anchorNextNode.webkitMatchesSelector && anchorNextNode.webkitMatchesSelector('span.mathjax'));

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2159,7 +2159,7 @@ var keyHandlers = {
             leftRange.setStartBefore(anchorPreviousNode);
             leftRange.setEndBefore(anchorPreviousNode);
 
-            if (isGecko && anchorPreviousNode.previousSibling && anchorPreviousNode.previousSibling.textContent) {
+            if (isGecko && anchorPreviousNode.previousSibling && anchorPreviousNode.previousSibling.nodeType === TEXT_NODE) {
                 var beforePreviousNode = anchorPreviousNode.previousSibling;
                 leftRange.setStart(beforePreviousNode, beforePreviousNode.textContent.length);
                 leftRange.setEnd(beforePreviousNode, beforePreviousNode.textContent.length);

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2142,26 +2142,33 @@ var keyHandlers = {
         // Test conditions for selection being at the start of the textnode.
         var validNodes = !!(anchorNode && anchorPreviousNode);
         var caretAtStartOfNode = selection.anchorOffset === 0;
-
+        var isMathjaxIOS, isMathjaxIE, isMathjax;
         // Test is SPAN and has mathjax class.
-        var isMathjaxIOS = !!(validNodes && anchorPreviousNode.webkitMatchesSelector && anchorPreviousNode.webkitMatchesSelector('span.mathjax'));
-        var isMathjaxIE = !!(validNodes && anchorPreviousNode.msMatchesSelector && anchorPreviousNode.msMatchesSelector('span.mathjax'));
-        var isMathjax  = !!(validNodes && anchorPreviousNode.matches && anchorPreviousNode.matches('span.mathjax'));
+        isMathjaxIOS = !!(validNodes && anchorPreviousNode.webkitMatchesSelector && anchorPreviousNode.webkitMatchesSelector('span.mathjax'));
+        isMathjaxIE = !!(validNodes && anchorPreviousNode.msMatchesSelector && anchorPreviousNode.msMatchesSelector('span.mathjax'));
+        isMathjax  = !!(validNodes && anchorPreviousNode.matches && anchorPreviousNode.matches('span.mathjax'));
+
+        // create a range to set the selection to.
+        var leftRange = self._doc.createRange();
 
         if (caretAtStartOfNode && (isMathjax || isMathjaxIE || isMathjaxIOS)) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 
             // create a new range
-            var leftRange = self._doc.createRange();
             leftRange.setStartBefore(anchorPreviousNode);
             leftRange.setEndBefore(anchorPreviousNode);
-            
+
+            if (isGecko && anchorPreviousNode.previousSibling && anchorPreviousNode.previousSibling.textContent) {
+                var beforePreviousNode = anchorPreviousNode.previousSibling;
+                leftRange.setStart(beforePreviousNode, beforePreviousNode.textContent.length);
+                leftRange.setEnd(beforePreviousNode, beforePreviousNode.textContent.length);
+            }
+
             // set a selection.
             self.setSelection(leftRange);
+            return;
         }
-
-        self._removeZWS();
     },
     right: function ( self, event, range) {
         var selection = self._doc.getSelection();


### PR DESCRIPTION
Fix Firefox issues:
- Not being able to use arrow keys to navigate past equations.
- Fix backspace (again, firefox wasn't buying into any of the old hacks).
