### PR TITLE
#96511482 Change key bindings for Squire

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1233,13 +1233,11 @@ var spanToSemantic = {
     fontWeight: {
         regexp: /^bold/i,
         replace: function ( doc ) {
-            return createElement( doc, 'B' );
         }
     },
     fontStyle: {
         regexp: /^italic/i,
         replace: function ( doc ) {
-            return createElement( doc, 'I' );
         }
     },
     fontFamily: {
@@ -2222,12 +2220,6 @@ if ( isMac && isGecko && win.getSelection().modify ) {
     };
 }
 
-keyHandlers[ ctrlKey + 'b' ] = mapKeyToFormat( 'B' );
-keyHandlers[ ctrlKey + 'i' ] = mapKeyToFormat( 'I' );
-keyHandlers[ ctrlKey + 'u' ] = mapKeyToFormat( 'U' );
-keyHandlers[ ctrlKey + 'shift-7' ] = mapKeyToFormat( 'S' );
-keyHandlers[ ctrlKey + 'shift-5' ] = mapKeyToFormat( 'SUB', { tag: 'SUP' } );
-keyHandlers[ ctrlKey + 'shift-6' ] = mapKeyToFormat( 'SUP', { tag: 'SUB' } );
 keyHandlers[ ctrlKey + 'shift-8' ] = mapKeyTo( 'makeUnorderedList' );
 keyHandlers[ ctrlKey + 'shift-9' ] = mapKeyTo( 'makeOrderedList' );
 keyHandlers[ ctrlKey + '[' ] = mapKeyTo( 'decreaseQuoteLevel' );
@@ -2516,19 +2508,7 @@ proto.addStyles = function ( styles ) {
     return this;
 };
 
-proto.bold = command( 'changeFormat', { tag: 'B' } );
-proto.italic = command( 'changeFormat', { tag: 'I' } );
-proto.underline = command( 'changeFormat', { tag: 'U' } );
-proto.strikethrough = command( 'changeFormat', { tag: 'S' } );
-proto.subscript = command( 'changeFormat', { tag: 'SUB' }, { tag: 'SUP' } );
-proto.superscript = command( 'changeFormat', { tag: 'SUP' }, { tag: 'SUB' } );
 
-proto.removeBold = command( 'changeFormat', null, { tag: 'B' } );
-proto.removeItalic = command( 'changeFormat', null, { tag: 'I' } );
-proto.removeUnderline = command( 'changeFormat', null, { tag: 'U' } );
-proto.removeStrikethrough = command( 'changeFormat', null, { tag: 'S' } );
-proto.removeSubscript = command( 'changeFormat', null, { tag: 'SUB' } );
-proto.removeSuperscript = command( 'changeFormat', null, { tag: 'SUP' } );
 
 proto.makeLink = function ( url, attributes ) {
     var range = this.getSelection();

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1233,11 +1233,13 @@ var spanToSemantic = {
     fontWeight: {
         regexp: /^bold/i,
         replace: function ( doc ) {
+            return createElement( doc, 'strong' );
         }
     },
     fontStyle: {
         regexp: /^italic/i,
         replace: function ( doc ) {
+            return createElement( doc, 'em' );
         }
     },
     fontFamily: {
@@ -2220,6 +2222,8 @@ if ( isMac && isGecko && win.getSelection().modify ) {
     };
 }
 
+keyHandlers[ ctrlKey + 'b' ] = mapKeyToFormat( 'strong' );
+keyHandlers[ ctrlKey + 'i' ] = mapKeyToFormat( 'em' );
 keyHandlers[ ctrlKey + 'shift-8' ] = mapKeyTo( 'makeUnorderedList' );
 keyHandlers[ ctrlKey + 'shift-9' ] = mapKeyTo( 'makeOrderedList' );
 keyHandlers[ ctrlKey + '[' ] = mapKeyTo( 'decreaseQuoteLevel' );
@@ -2508,7 +2512,11 @@ proto.addStyles = function ( styles ) {
     return this;
 };
 
+proto.bold = command( 'changeFormat', { tag: 'strong' } );
+proto.italic = command( 'changeFormat', { tag: 'em' } );
 
+proto.removeBold = command( 'changeFormat', null, { tag: 'strong' } );
+proto.removeItalic = command( 'changeFormat', null, { tag: 'em' } );
 
 proto.makeLink = function ( url, attributes ) {
     var range = this.getSelection();

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1299,8 +1299,8 @@ var stylesRewriters = {
 
         return newTreeBottom || span;
     },
-    STRONG: replaceWithTag( 'B' ),
-    EM: replaceWithTag( 'I' ),
+    STRONG: replaceWithTag( 'strong' ),
+    EM: replaceWithTag( 'em' ),
     STRIKE: replaceWithTag( 'S' ),
     FONT: function ( node, parent ) {
         var face = node.face,


### PR DESCRIPTION
We're only going to be supporting bold and italics through strong & em for the near future, so we're removing the key bindings for italics, strikethrough, subscript, superscript etc. We're also replacing the b tag with strong and the i tag with em.
