### PR TITLE
[#96966814] Fix IE9 Inconsistencies.

### DIFF
--- a/source/Constants.js
+++ b/source/Constants.js
@@ -17,7 +17,6 @@ var win = doc.defaultView;
 
 var ua = navigator.userAgent;
 
-var isIE9 = ua.match('MSIE 9');
 var isIOS = /iP(?:ad|hone|od)/.test( ua );
 var isMac = /Mac OS X/.test( ua );
 

--- a/source/Constants.js
+++ b/source/Constants.js
@@ -17,6 +17,8 @@ var win = doc.defaultView;
 
 var ua = navigator.userAgent;
 
+var isIE9 = ua.match('MSIE 9');
+
 var isIOS = /iP(?:ad|hone|od)/.test( ua );
 var isMac = /Mac OS X/.test( ua );
 

--- a/source/Constants.js
+++ b/source/Constants.js
@@ -18,7 +18,6 @@ var win = doc.defaultView;
 var ua = navigator.userAgent;
 
 var isIE9 = ua.match('MSIE 9');
-
 var isIOS = /iP(?:ad|hone|od)/.test( ua );
 var isMac = /Mac OS X/.test( ua );
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2021,7 +2021,7 @@ var keyHandlers = {
             // Delete the equation if we are trying to delete the space infront of it, no browser copes well with a span tag sitting in the DOM with no text nodes next to it.
 
             if (anchorNode.textContent && anchorNode.textContent.length) {
-                var caretAtStartOfNode = !!(anchorOffset === 0) || !!(anchorOffset === 1 && anchorNode.textContent.length === 1);
+                var caretAtStartOfNode = !!(anchorOffset === 0) || !!(anchorOffset === 1 && anchorNode.textContent.length === 1) && /[ ]/g.test(anchorNode.textContent);
             } else {
                 var caretAtStartOfNode = !!(anchorOffset === 0);
             }

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1908,12 +1908,16 @@ var keyHandlers = {
             // Using cloneNode means that the childNodes are not elements of the original node.
             while (childNodes.length != 1) {
                 ancestor.removeChild(childNodes[0]);
-            }            
-            ancestor.innerHTML = " <br>";
-            var ancestorRange = self._doc.createRange();
-            ancestorRange.setStartAfter(ancestor);
-            ancestorRange.setEndBefore(ancestor);
-            self.setSelection(ancestorRange);
+            }
+            
+            if (ancestor) {
+                ancestor.innerHTML = " <br>";
+
+                var ancestorRange = self._doc.createRange();
+                ancestorRange.setStartAfter(ancestor);
+                ancestorRange.setEndBefore(ancestor);
+                self.setSelection(ancestorRange);
+            }
         }
         // If at beginning of block, merge with previous
         else if ( rangeDoesStartAtBlockBoundary( range ) ) {
@@ -2016,8 +2020,11 @@ var keyHandlers = {
             var selection = self._doc.getSelection();
             var anchorNode = selection.anchorNode;
             var anchorOffset = selection.anchorOffset;
-            var previousSibling = anchorNode.previousSibling;
 
+            if (anchorNode) {
+                var previousSibling = anchorNode && anchorNode.previousSibling;
+            }
+            
             // Delete the equation if we are trying to delete the space infront of it, no browser copes well with a span tag sitting in the DOM with no text nodes next to it.
 
             if (anchorNode.textContent && anchorNode.textContent.length) {
@@ -2145,7 +2152,10 @@ var keyHandlers = {
         if(!selection.anchorNode) { return; }
 
         var anchorNode = selection.anchorNode;
-        var anchorPreviousNode = anchorNode.previousSibling;
+
+        if (anchorNode) {
+            var anchorPreviousNode = anchorNode.previousSibling;
+        }
 
         // Test conditions for selection being at the start of the textnode.
         var validNodes = !!(anchorNode && anchorPreviousNode);

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2149,15 +2149,13 @@ var keyHandlers = {
         var selection = self._doc.getSelection();
         // We're not interested in things that are not Carets.
         if (!selection.isCollapsed) { return; }
-        
-        // or anything that doesn't have an anchorNode.
-        if(!selection.anchorNode) { return; }
 
         var anchorNode = selection.anchorNode;
+        
+        // We're not interested in ranges that do not have an anchorNode.
+        if (!anchorNode) { return; }
 
-        if (anchorNode) {
-            var anchorPreviousNode = anchorNode.previousSibling;
-        }
+        var anchorPreviousNode = anchorNode.previousSibling;
 
         // Test conditions for selection being at the start of the textnode.
         var validNodes = !!(anchorNode && anchorPreviousNode);

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1909,7 +1909,8 @@ var keyHandlers = {
             while (childNodes.length != 1) {
                 ancestor.removeChild(childNodes[0]);
             }
-            
+
+            // IE9 can send the commonAncestorContainer of the range as undefined.
             if (ancestor) {
                 ancestor.innerHTML = " <br>";
 
@@ -2003,6 +2004,7 @@ var keyHandlers = {
                     (
                         (isIE9 && currentSearchNode.className.match('mathjax')) || 
                         (!isIE9 && currentSearchNode.classList.contains('mathjax'))
+                        // IE9 has no support for classList. It is only supported in 10+.
                     ) 
                 ) {
                     mathjaxSpan = currentSearchNode;
@@ -2021,14 +2023,14 @@ var keyHandlers = {
             var anchorNode = selection.anchorNode;
             var anchorOffset = selection.anchorOffset;
 
+            // A range can have no anchorNode in IE9.
             if (anchorNode) {
-                var previousSibling = anchorNode && anchorNode.previousSibling;
+                var previousSibling = anchorNode.previousSibling;
             }
             
             // Delete the equation if we are trying to delete the space infront of it, no browser copes well with a span tag sitting in the DOM with no text nodes next to it.
-
             if (anchorNode.textContent && anchorNode.textContent.length) {
-                var caretAtStartOfNode = !!(anchorOffset === 0) || !!(anchorOffset === 1 && anchorNode.textContent.length === 1) && /[ ]/g.test(anchorNode.textContent);
+                var caretAtStartOfNode = !!(anchorOffset === 0) || !!(anchorOffset === 1 && anchorNode.textContent.length === 1) && /[ ]/g.test(anchorNode.textContent); // Confirm the anchorNode is empty and does not contain a character.
             } else {
                 var caretAtStartOfNode = !!(anchorOffset === 0);
             }

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1995,7 +1995,12 @@ var keyHandlers = {
             var mathjaxSpan = null;
 
             while ( currentSearchNode !== self._doc.body) {
-                if (currentSearchNode.nodeType === ELEMENT_NODE && currentSearchNode.classList.contains('mathjax')) {
+                if (currentSearchNode.nodeType === ELEMENT_NODE && 
+                    (
+                        (isIE9 && currentSearchNode.className.match('mathjax')) || 
+                        (!isIE9 && currentSearchNode.classList.contains('mathjax'))
+                    ) 
+                ) {
                     mathjaxSpan = currentSearchNode;
                     break;
                 }

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -14,6 +14,16 @@ function getSquireInstance ( doc ) {
     return null;
 }
 
+//Polyfill for element.matches, makes things much less sucky
+function elMatchesSelector(el, selector) {
+    var matchFn = el.matches || el.matchesSelector || el.webkitMatchesSelector || el.msMatchesSelector;
+    if (!matchFn) {
+        throw new Error('This browser appears to have no Element.matches implementation');
+    }
+
+    return matchFn.bind(el)(selector);
+}
+
 function Squire ( doc ) {
     var win = doc.defaultView;
     var body = doc.body;
@@ -2040,11 +2050,8 @@ var keyHandlers = {
                 // Is an empty text node, backspace has been pressed
                 // and it's previous sibling is a mathjax equation
                 // then remove both elements.
-                var isMathjaxIOS = !!(previousSibling.webkitMatchesSelector && previousSibling.webkitMatchesSelector('span.mathjax'));
-                var isMathjaxIE = !!(previousSibling.msMatchesSelector && previousSibling.msMatchesSelector('span.mathjax'));
-                var isMathjax  = !!(previousSibling.matches && previousSibling.matches('span.mathjax'));
-                
-                if (isMathjaxIOS || isMathjaxIE || isMathjax) {
+                var isMathjax = elMatchesSelector(previousSibling, 'span.mathjax');
+                if (isMathjax) {
                     event.preventDefault();
                     detach(previousSibling);
                 }
@@ -2162,14 +2169,12 @@ var keyHandlers = {
         var caretAtStartOfNode = selection.anchorOffset === 0;
         
         // Test is SPAN and has mathjax class.
-        var isMathjaxIOS = !!(validNodes && anchorPreviousNode.webkitMatchesSelector && anchorPreviousNode.webkitMatchesSelector('span.mathjax'));
-        var isMathjaxIE = !!(validNodes && anchorPreviousNode.msMatchesSelector && anchorPreviousNode.msMatchesSelector('span.mathjax'));
-        var isMathjax  = !!(validNodes && anchorPreviousNode.matches && anchorPreviousNode.matches('span.mathjax'));
+        var isMathjax = !!(validNodes && elMatchesSelector(anchorPreviousNode, 'span.mathjax'));
 
         // create a range to set the selection to.
         var leftRange = self._doc.createRange();
 
-        if (caretAtStartOfNode && (isMathjax || isMathjaxIE || isMathjaxIOS)) {
+        if (caretAtStartOfNode && isMathjax) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 
@@ -2201,11 +2206,9 @@ var keyHandlers = {
         var caretIsAtEndOfNode = selection.anchorOffset === anchorNode.textContent.length;
         var validNodes = !!(anchorNode && anchorNextNode);
         // Test is SPAN and has mathjax class.
-        var isMathjaxIOS = !!(validNodes && anchorNextNode.webkitMatchesSelector && anchorNextNode.webkitMatchesSelector('span.mathjax'));
-        var isMathjaxIE = !!(validNodes && anchorNextNode.msMatchesSelector && anchorNextNode.msMatchesSelector('span.mathjax'));
-        var isMathjax  = !!(validNodes && anchorNextNode.matches && anchorNextNode.matches('span.mathjax'));
+        var isMathjax = !!(validNodes && elMatchesSelector(anchorNextNode, 'span.mathjax'));
 
-        if (caretIsAtEndOfNode && (isMathjax || isMathjaxIE || isMathjaxIOS)) {
+        if (caretIsAtEndOfNode && isMathjax) {
             // this is a mathjax equation, prevent defualt.
             event.preventDefault();
 

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -2010,17 +2010,11 @@ var keyHandlers = {
             var mathjaxSpan = null;
 
             while ( currentSearchNode !== self._doc.body) {
-                if (currentSearchNode.nodeType === ELEMENT_NODE && 
-                    (
-                        (isIE9 && currentSearchNode.className.match('mathjax')) || 
-                        (!isIE9 && currentSearchNode.classList.contains('mathjax'))
-                        // IE9 has no support for classList. It is only supported in 10+.
-                    ) 
-                ) {
+                if (currentSearchNode.nodeType === ELEMENT_NODE && elMatchesSelector(currentSearchNode, '.mathjax')) {
                     mathjaxSpan = currentSearchNode;
                     break;
                 }
-                
+
                 currentSearchNode = currentSearchNode.parentNode;
             }
 


### PR DESCRIPTION
IE9 doesn't return null for previousSibling when an element does not have a previousSibling, instead it returns undefined. Generally, this cleans up inconsistencies & cases where the anchorNode or it's properties were not defined.

Also, flagged the small issue that when an equation has a character that was or was not a space and that character was deleted, the equation was deleted. The equation should only be deleted when the space (empty character) in front of it is deleted. 

Once merged, this will pave the way for Squire being used on IE9 in a reduced form (no ability to create equations or edit them, but the ability to delete equations and modify text).
